### PR TITLE
Bugfix keyboard trigger

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsmpc",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "homepage": "https://github.com/",
   "dependencies": {

--- a/src/App.js
+++ b/src/App.js
@@ -27,6 +27,10 @@ export default function App() {
   )
 
   function onKeyDown(event) {
+    if (event.repeat) {
+      return
+    }
+
     const key = event.key
     samplePlayer.playSample(key)
     setPadIsTriggered(key, true)

--- a/src/App.js
+++ b/src/App.js
@@ -16,7 +16,14 @@ export default function App() {
   const [pads, setPads] = useState(padsData)
 
   return (
-    <AppStyled onKeyDown={onKeyDown} onKeyUp={onKeyUp} tabIndex="0">
+    <AppStyled
+      onKeyDown={onKeyDown}
+      onKeyUp={onKeyUp}
+      onContextMenu={event => {
+        event.preventDefault()
+      }}
+      tabIndex="0"
+    >
       <PadSection
         pads={pads}
         handlePadTouchStart={handlePadTouchStart}

--- a/src/App.js
+++ b/src/App.js
@@ -29,33 +29,33 @@ export default function App() {
   function onKeyDown(event) {
     const key = event.key
     samplePlayer.playSample(key)
-    togglePadTriggerStatus(key)
+    setPadIsTriggered(key, true)
   }
 
   function onKeyUp(event) {
     const key = event.key
-    togglePadTriggerStatus(key)
+    setPadIsTriggered(key, false)
   }
 
   function handlePadTouchStart(event) {
     const name = getElementNameByEvent(event)
     const key = getKeyByName(name)
     samplePlayer.playSample(key)
-    togglePadTriggerStatus(key)
+    setPadIsTriggered(key, true)
   }
 
   function handlePadTouchEnd(event) {
     stopPinchZooming(event)
     const name = getElementNameByEvent(event)
     const key = getKeyByName(name)
-    togglePadTriggerStatus(key)
+    setPadIsTriggered(key, false)
   }
 
-  function togglePadTriggerStatus(key) {
+  function setPadIsTriggered(key, triggerd) {
     const index = pads.findIndex(pad => pad.key === key)
     if (index > -1) {
       const pad = { ...pads[index] }
-      pad.isTriggered = !pad.isTriggered
+      pad.isTriggered = triggerd
       const newPads = updateInArray(pads, pad, index)
       setPads(newPads)
     }


### PR DESCRIPTION
There are some bugs which need to get fixed:

On keyboard triggering if you hold a key down, the key get's triggered on repeat. This should not be possible. Holding a key down should trigger the sound only on time.

On keyboard triggering if you hold a key down and the sound repeats, the padTrigger status not get updated correctly. This effects that the border color of a pad not updates correctly.

If you hold down a touch after a few seconds on desktops the context menu opens.